### PR TITLE
Updating the version number for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.3.5]](https://github.com/lightspeeddevelopment/lsx-sharing/releases/tag/1.3.5) - 2023-08-18
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[1.3.4]](https://github.com/lightspeeddevelopment/lsx-sharing/releases/tag/1.3.4) - 2023-04-20
 
 ### Security

--- a/lsx-team.php
+++ b/lsx-team.php
@@ -3,7 +3,7 @@
  * Plugin Name: LSX Team
  * Plugin URI:  https://www.lsdev.biz/product/lsx-team/
  * Description: The LSX Team extension provides a custom post type that allows you to easily show off the people that make up your business.
- * Version:     1.3.4
+ * Version:     1.3.5
  * Author:      LightSpeed
  * Author URI:  https://www.lsdev.biz/
  * License:     GPL3
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_TEAM_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_TEAM_CORE', __FILE__ );
 define( 'LSX_TEAM_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_TEAM_VER', '1.3.4' );
+define( 'LSX_TEAM_VER', '1.3.5' );
 
 
 /* ======================= Below is the Plugin Class init ========================= */

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, team, team members, our team, block editor support
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.0
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description

- Updating the stable tag and version number.
- Security testing for WordPress 6.3